### PR TITLE
c3js/c3 PR 1576 -- Uncaught TypeError: Cannot read property 'x' of null

### DIFF
--- a/v/eon/0.0.10/eon.js
+++ b/v/eon/0.0.10/eon.js
@@ -6605,7 +6605,8 @@ if(t==e.dx){for((r||s>e.dy)&&(s=e.dy);++i<a;)u=n[i],u.x=o,u.y=c,u.dy=s,o+=u.dx=M
                         translateX = diffDomain(domain) / 2;
                     }
                 }
-            } else if (flow.orgDataCount === 1 || flowStart.x === flowEnd.x) {
+//            } else if (flow.orgDataCount === 1 || flowStart.x === flowEnd.x) {
+              } else if (flow.orgDataCount === 1 || (flowStart && flowStart.x) === (flowEnd && flowEnd.x)) {
                 translateX = $$.x(orgDomain[0]) - $$.x(domain[0]);
             } else {
                 if ($$.isTimeSeries()) {


### PR DESCRIPTION
6608 is a broken line of code carried over from c3js/c3 - see PR 1576 and https://github.com/c3js/c3/issues/1235
If there are no data, flowStart.x gives Uncaught TypeError: Cannot read property 'x' of null
Fix as suggested by jakerella is to replace line with:
} else if (flow.orgDataCount === 1 || (flowStart && flowStart.x) === (flowEnd && flowEnd.x)) {